### PR TITLE
Update Connexion to Version 2.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.8.0" %}
+{% set version = "2.9.0" %}
 
 package:
   name: connexion
@@ -7,7 +7,7 @@ package:
 source:
   fn: {{ version }}.tar.gz
   url: https://github.com/zalando/connexion/archive/{{ version }}.tar.gz
-  sha256: ec8d429b1a677762158094b169414e9e48dd952db4330cd1583092e25f2e2770
+  sha256: 6411b71cfb9d8cbdf1c884d4247e6c64bbf9cef5582e641733ada827bb5f9726
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<37]
+  # missing dependencies for s390x
+  skip: True  # [py<37 or s390x]
   script: "{{ PYTHON }} -m pip install . -vv"
   entry_points:
     - connexion = connexion.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,14 @@ source:
 build:
   number: 0
   noarch: python
+  skip: True  # [py<37]
   script: "{{ PYTHON }} -m pip install . -vv"
   entry_points:
     - connexion = connexion.cli:main
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - flake8
     - setuptools
@@ -49,6 +50,7 @@ test:
 
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
     - connexion --version


### PR DESCRIPTION
connexion 2.9.0

1. check the upstream
https://github.com/zalando/connexion/tree/2.9.0

2. check the pinnings
https://github.com/zalando/connexion/blob/2.9.0/tox.ini
https://github.com/zalando/connexion/blob/2.9.0/setup.py

Since python 3.6 is required in the pinnings, the python requiirements were not updated too 3.7
https://github.com/zalando/connexion/blob/2.9.0/tox.ini#L19

3. check changelogs
https://github.com/zalando/connexion/releases

Most of the changes mentioned were only new features or bug fixes:

2.9.0 Latest

Notable changes:

- support required: false for headers `#1293`
- support multiple security schemes `#1290`
- better handling of numerical path parameters in `Flask` `#1290`
- Detailed list of changes: https://github.com/zalando/connexion/milestone/12

4. additional research
https://github.com/conda-forge/connexion-feedstock/issues

5. verify dev_url
    dev_url: https://github.com/zalando/connexion
6. verify doc_url
    doc_url: https://connexion.readthedocs.io/

7. verify that pip is in the test section
8. verify the test section
9. additional tests

/Users/cvarlack/miniconda3/envs/c3i-test/conda-bld/noarch/connexion-2.9.0-pyhd3eb1b0_0.tar.bz2


In order to test the `connexion` package version `2.9.0` the following command was used:
`conda build connexion-feedstock --test` 
The test result was the following:
`All tests passed`

Since there are no packages depending on `connexion 2.9.0` an import test was not conducted.

Based on the research findings and on the test results we can conclude that it is safe to update `connexion` to version `2.9.0`
