### PR TITLE
connexion 3.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/python-multipart-feedstock/pr5/fea8992

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/python-multipart-feedstock/pr5/fea8992
+  - https://staging.continuum.io/prefect/fs/python-multipart-feedstock/pr5/06946df

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/python-multipart-feedstock/pr5/06946df

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   # inflection >=0.3.1 and <0.6 is not present on s390x
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,12 @@ requirements:
     - starlette >=0.35
     - typing-extensions >=4.6.1
     - werkzeug >=2.2.1
+  run_constrained:
+    - a2wsgi >=1.7
+    - flask >=2.2
+    - swagger-ui-bundle >=1.1.0
+    - uvicorn >=0.17.6
+    - jsf >=0.10.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,49 +7,46 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/connexion-{{ version }}.tar.gz
-  sha256: ed6f9c97ca5281257935c5530570b2a2394a689ece1b171c18d855cf751adbb4
+  sha256: 0715d4a0393437aa2a48c144756360f9b5292635a05fd15c38cbbaf04ef5acb9
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - connexion = connexion.cli:main
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   # inflection >=0.3.1 and <0.6 is not present on s390x
-  skip: True  # [linux and s390x]
+  skip: True  # [py<38 or s390x]
+
 requirements:
   host:
     - python
     - pip
     - setuptools
     - wheel
-    - mccabe >=0.6.0,<0.7.0
-    - flake8
-    - importlib-metadata <4.3
-
+    - poetry-core >=1.2.0
   run:
     - python
-    - clickclick >=1.2,<21
-    # from upstream only for py<38, but let's keep it noarch: python
-    - importlib-metadata >=1
-    - inflection >=0.3.1,<0.6
-    - jsonschema >=2.5.1,<5
-    - packaging >=20
-    - pyyaml >=5.1,<7
-    - requests >=2.9.1,<3
-    - werkzeug >=1.0,<3.0
-    # note: install_requires includes flask_require:
-    - flask >=1.0.4,<3
-    - itsdangerous >=0.24
+    - asgiref >=3.4
+    - httpx >=0.23
+    - inflection >=0.3.1
+    - jsonschema >=4.17.3
+    - Jinja2 >=3.0.0
+    - python-multipart >=0.0.15
+    - PyYAML >=5.1
+    - requests >=2.27
+    - starlette >=0.35
+    - typing-extensions >=4.6.1
+    - werkzeug >=2.2.1
 
 test:
   requires:
     - pip
   imports:
     - connexion
-    - connexion.apis
     - connexion.apps
     - connexion.decorators
+    - connexion.middleware
+    - connexion.operations
+    - connexion.resources
+    - connexion.validators
   commands:
     - connexion --version
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,8 @@ test:
     - connexion.resources
     - connexion.validators
   commands:
-    - connexion --version
+    - connexion --version  # [unix]
+    - python -m connexion --version  # [win]
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
   license: Apache-2.0
   summary: Swagger/OpenAPI First framework for Python on top of Flask with automatic endpoint validation & OAuth2 support
   license_family: APACHE
-  license_file: LICENSE.txt
+  license_file: LICENSE
   dev_url: https://github.com/zalando/connexion
   doc_url: https://connexion.readthedocs.io/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
   home: https://github.com/zalando/connexion
   license: Apache-2.0
   summary: Swagger/OpenAPI First framework for Python on top of Flask with automatic endpoint validation & OAuth2 support
+  description: Connexion is a modern Python web framework that makes spec-first and api-first development easy.
   license_family: APACHE
   license_file: LICENSE
   dev_url: https://github.com/zalando/connexion

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "connexion" %}
-{% set version = "2.14.0" %}
+{% set version = "3.2.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7428](https://anaconda.atlassian.net/browse/PKG-7428)
- [Upstream repository](https://github.com/spec-first/connexion/tree/3.2.0)
- [Upstream changelog/diff](https://github.com/spec-first/connexion/releases)


### Explanation of changes:

- Update version and sha256
- Skip python < 3.8 and s390x
- Update host and run requirements
- Update test imports
- Linter fixes
- Build for python 3.13


[PKG-7428]: https://anaconda.atlassian.net/browse/PKG-7428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ